### PR TITLE
SSL & Overpass bug Fix

### DIFF
--- a/src/assets/js/app/main.js
+++ b/src/assets/js/app/main.js
@@ -12,14 +12,22 @@ define([
     ], function($, _, leaflet, Backbone, Slider, moment, ThreeDScene, Mediator, Map, Form) {
 
         var FOURSQUARE_URL = 'https://d310g5te00bhi.cloudfront.net/v2/venues/search\?client_id\=FNJEOV4QV4YBMJ4J5EQNKQTCQXOQBCUSIIYIZAXWMKLY5XPN\&client_secret\=NEKCZ4IFX4SOJEPDY2E1ZIV4NTAYZ3GWQHWKKPSQF3KOZKCS\&v\=1396279715756\&ll\={lat}%2C{lng}\&radius\=500\&intent\=browse\&limit\=50\&categoryId\=4bf58dd8d48988d11b941735%2C4bf58dd8d48988d116941735'
-        var OVERPASS_URL = 'http://overpasscache.pintsinthesun.co.uk/api/interpreter?data=[out:json];((way({bounds})[%22building%22]);(._;node(w);););out;'
+        
+        // Replaced overpass URL with more performant server (which supports SSL, too). Commenting old URL
+        var OVERPASS_URL = 'https://overpass.kumi.systems/api/interpreter?data=[out:json];((way({bounds})[%22building%22]);(._;node(w);););out;'
+        // var OVERPASS_URL = 'http://overpasscache.pintsinthesun.co.uk/api/interpreter?data=[out:json];((way({bounds})[%22building%22]);(._;node(w);););out;'
+        
         var OVERPASS_BOUND = 0.0011;
         var ROADS = false;
         var FS_PRECISION = 1000;
 
         if(ROADS) {
+                
             // Extra query part to fetch roads data
-            OVERPASS_URL = 'http://overpasscache.pintsinthesun.co.uk/api/interpreter?data=[out:json];((way({bounds})[%22building%22]);(._;node(w);way({bounds})[%22highway%22]);(._;node(w);););out;';
+                
+            // Replaced overpass URL with more performant server (which supports SSL, too). Commenting old URL
+            OVERPASS_URL = 'https://overpass.kumi.systems/api/interpreter?data=[out:json];((way({bounds})[%22building%22]);(._;node(w);way({bounds})[%22highway%22]);(._;node(w);););out;';
+            // OVERPASS_URL = 'http://overpasscache.pintsinthesun.co.uk/api/interpreter?data=[out:json];((way({bounds})[%22building%22]);(._;node(w);way({bounds})[%22highway%22]);(._;node(w);););out;';
         }
 
         var pintIcon = L.icon({

--- a/src/assets/js/app/map.js
+++ b/src/assets/js/app/map.js
@@ -4,9 +4,9 @@ define([
         'mediator'
     ], function($, _, Mediator) {
 
-        var cloudmadeUrl = 'http://{s}.tile.cloudmade.com/1a1b06b230af4efdbb989ea99e9841af/997/256/{z}/{x}/{y}.png';
-        var osmUrl = 'http://a.tile.openstreetmap.org/{z}/{x}/{y}.png';
-        var tileProvider = 'http://a.tiles.mapbox.com/v3/poke.ifimp0gk/{z}/{x}/{y}.png';
+        var cloudmadeUrl = 'https://{s}.tile.cloudmade.com/1a1b06b230af4efdbb989ea99e9841af/997/256/{z}/{x}/{y}.png';
+        var osmUrl = 'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png';
+        var tileProvider = 'https://a.tiles.mapbox.com/v3/poke.ifimp0gk/{z}/{x}/{y}.png';
         var defaultCentre = {lat: 51.524312, lng: -0.076432};
 
         var Map = function() {


### PR DESCRIPTION
Recent browsers version were blocking requests to the overpass server (http resource), as well as showing warning for other non secure http resources.

- Updated all http urls to https
- Switched old Overpass server (https://overpasscache.pintsinthesun.co.uk) to a more performant one (https://overpass.kumi.systems/api/interpreter). See: [https://wiki.openstreetmap.org/wiki/Overpass_API#Public_Overpass_API_instances](url)